### PR TITLE
플러그인 적용한 draft

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -26,6 +26,7 @@ const getClientEnvironment = require('./env');
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
+const lodashModulePlugin = require('lodash-webpack-plugin');
 const eslint = require('eslint');
 
 const postcssNormalize = require('postcss-normalize');

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "jest-environment-jsdom-fourteen": "0.1.0",
     "jest-resolve": "24.8.0",
     "jest-watch-typeahead": "0.3.1",
+    "lodash": "^4.17.15",
+    "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "0.5.0",
     "node-sass": "^4.12.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",
@@ -92,6 +94,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.144",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/eslint-plugin-tslint": "^2.3.3",
     "cross-env": "^5.2.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import {Route} from 'react-router';
 import Layout from './layouts/Layout';
 
 class App extends React.Component  {
-  render(): ReactNode {
+  render (): ReactNode {
     return (
       <div>
         <Route path="/" component={Layout}/>

--- a/src/components/Gnb.tsx
+++ b/src/components/Gnb.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default class TestComponentOne extends React.Component {
-  render() {
+  render () {
     return (
       <div>
         <span>link 1</span>

--- a/src/components/TestComponentOne.tsx
+++ b/src/components/TestComponentOne.tsx
@@ -1,7 +1,7 @@
 import React, {ReactNode} from 'react';
 
 export default class TestComponentOne extends React.Component {
-  render(): ReactNode {
+  render (): ReactNode {
     return (
       <div>this is test component one</div>
     );

--- a/src/components/TestComponentTwo.tsx
+++ b/src/components/TestComponentTwo.tsx
@@ -1,7 +1,7 @@
 import React, {ReactNode} from 'react';
 
 export default class TestComponentTwo extends React.Component {
-  render(): ReactNode {
+  render (): ReactNode {
     return (
       <div>this is test component two</div>
     );

--- a/src/components/block/TitleProvider.tsx
+++ b/src/components/block/TitleProvider.tsx
@@ -1,0 +1,24 @@
+import React, {ReactNode} from 'react';
+
+export interface TitleProviderProps {
+
+}
+
+/**
+ * Base class of TitleProvider which has responsibility to draw
+ * Title of block. Plugin maker should extends this abstract class
+ * To provide TitleProvider
+ *
+ * method : Native react render function
+ * method : Returns raw text of TitleProvider
+ */
+export default abstract class TitleProvider<T> extends React.Component<T & TitleProviderProps> {
+
+  constructor (props: any) {
+    super(props);
+  }
+
+  abstract render (): ReactNode;
+  abstract getTitleText (): string;
+
+}

--- a/src/components/block/abstractBlockComponent/AbstractBlockComponent.tsx
+++ b/src/components/block/abstractBlockComponent/AbstractBlockComponent.tsx
@@ -5,14 +5,14 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
 
 }
 
-interface State {
+interface BlockState {
     mockText: string;
-    blockFocused: boolean;
+    editMode: true;
 }
 
-export default abstract class  AbstractBlockComponent extends React.Component {
+export default abstract class  AbstractBlockComponent<Props, State> extends React.Component<Props, State> {
 
-  constructor(props: HTMLAttributes<HTMLDivElement>){
+  constructor (props: Props){
     super(props);
   }
 
@@ -22,18 +22,18 @@ export default abstract class  AbstractBlockComponent extends React.Component {
 
     abstract onBlur(): void;
 
-    onLeftClick(event: React.MouseEvent<HTMLElement>): void {
+    onLeftClick (event: React.MouseEvent<HTMLElement>): void {
       if(event.ctrlKey){
         return this.onCtrlLeftClick();
       }
       return this.onNormalLeftClick();
     }
 
-    onRightClick(event: MouseEvent): void {
+    onRightClick (event: MouseEvent): void {
       event;
     }
 
-    onDrag(): void{
+    onDrag (): void{
 
     }
 }

--- a/src/components/block/compositeBlock/CompositeBlock.tsx
+++ b/src/components/block/compositeBlock/CompositeBlock.tsx
@@ -1,55 +1,68 @@
 import React, {HTMLAttributes, ReactNode} from 'react';
 import './styled.scss';
 import AbstractBlockComponent from '../abstractBlockComponent/AbstractBlockComponent';
-
-export interface Props extends HTMLAttributes<HTMLDivElement> {
-
+import CompositeBlockInteraction from '@domain/plugin/CompositeBlockInteraction';
+import {throttle} from 'lodash';
+import TitleProvider, {TitleProviderProps} from '@components/block/TitleProvider';
+export interface CompositeBlockProps extends HTMLAttributes<HTMLDivElement> {
+  interaction: CompositeBlockInteraction;
 }
 
-interface State {
+interface CompositeBlockState {
     mockText: string;
 }
 
 /**
  * Block that can be parent of other blocks
  */
-export default class CompositeBlockComponent extends AbstractBlockComponent {
+export default class CompositeBlockComponent<T>
+  extends AbstractBlockComponent<CompositeBlockProps, CompositeBlockState> {
 
-    public state: State
+    public state: CompositeBlockState;
+    public interaction: CompositeBlockInteraction;
+    private TitleProviderComponent: React.ReactElement<TitleProvider<TitleProviderProps>>;
 
-    public constructor(props: HTMLAttributes<HTMLDivElement>) {
+    public constructor (props: CompositeBlockProps) {
       super(props);
       this.state = {
         mockText: 'init'
       };
+
+      this.interaction = this.props.interaction;
+      this.TitleProviderComponent = this.interaction.titleProvider;
     }
 
-    public onRightClick(): void {
+    public onRightClick (): void {
     }
 
-    public onNormalLeftClick(): void {
+    public onNormalLeftClick (): void {
       this.setState({
         mockText: 'Composite block is currently does nothing'
       });
     }
 
-    public onCtrlLeftClick(): void {
+    public onCtrlLeftClick (): void {
 
     }
 
-    public onBlur(): void {
+    public onBlur (): void {
       this.setState({
         mockText: 'blurred'
       });
     }
 
-    public render(): ReactNode {
+    public render (): ReactNode {
+
       return(<div className={'item'}
-        onClick={this.onLeftClick.bind(this)}
+        onClick={this.interaction.leftClickHandler}
         onBlur={this.onBlur.bind(this)}
+        onMouseMove={
+          throttle(this.interaction.hoverHandler.bind(this.interaction), 500)
+        }
         tabIndex={0}
       >
-        <p>{this.state.mockText}</p>
+
+        {this.TitleProviderComponent}
       </div>);
     }
 }

--- a/src/components/block/leafBlockComponent/LeafBlockComponent.tsx
+++ b/src/components/block/leafBlockComponent/LeafBlockComponent.tsx
@@ -15,11 +15,11 @@ interface State {
 /**
  * Block that is literally a leaf.
  */
-export default class LeafBlockComponent extends AbstractBlockComponent {
+export default class LeafBlockComponent extends AbstractBlockComponent<Props, State> {
 
-    public state: State
+    public state: State;
 
-    public constructor(props: HTMLAttributes<HTMLDivElement>) {
+    public constructor (props: HTMLAttributes<HTMLDivElement>) {
       super(props);
       this.state = {
         mockText: 'init',
@@ -28,7 +28,7 @@ export default class LeafBlockComponent extends AbstractBlockComponent {
       };
     }
 
-    public drawComponent(): ReactNode {
+    public drawComponent (): ReactNode {
 
       if (this.state.editMode) {
         return (<input value={this.state.editText}
@@ -40,33 +40,33 @@ export default class LeafBlockComponent extends AbstractBlockComponent {
       return (<h2>{this.state.mockText}</h2>);
     }
 
-    public onRightClick(): void {
+    public onRightClick (): void {
 
     }
 
-    public onNormalLeftClick(): void {
+    public onNormalLeftClick (): void {
       this.setState({
         editMode: true
       });
     }
 
-    public onCtrlLeftClick(): void {
+    public onCtrlLeftClick (): void {
 
     }
 
-    public onBlur(): void {
+    public onBlur (): void {
 
     }
 
-    private onInputChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    private onInputChange (event: React.ChangeEvent<HTMLInputElement>): void {
       this.setState({
         ...this.state,
         editText: event.target.value,
-        mockTExt: event.target.value
+        mockText: event.target.value
       });
     }
 
-    private onInputBlur(event: React.ChangeEvent<HTMLInputElement>): void {
+    private onInputBlur (event: React.ChangeEvent<HTMLInputElement>): void {
       this.setState({
         ...this.state,
         editMode: false,
@@ -74,7 +74,7 @@ export default class LeafBlockComponent extends AbstractBlockComponent {
       });
     }
 
-    public render(): ReactNode {
+    public render (): ReactNode {
       return(<div className={'item'}
         onClick={this.onLeftClick.bind(this)}
         onBlurCapture={this.onBlur.bind(this)}

--- a/src/components/contentProvider/DefaultTitleProvider.tsx
+++ b/src/components/contentProvider/DefaultTitleProvider.tsx
@@ -1,0 +1,27 @@
+import React, {ReactNode} from 'react';
+import TitleProvider from '@components/block/TitleProvider';
+import TitleProviderOption from '@domain/types/TitleProviderOption';
+
+interface Props {
+  titleProvider: TitleProviderOption;
+}
+
+export default class DefaultTitleProvider<T> extends TitleProvider<Props> {
+
+  constructor (props: Props) {
+    super(props);
+  }
+
+  getTitleText (): string {
+    return 'foo';
+  }
+
+  render (): ReactNode {
+    return (<div>
+      <p style={{
+        color: this.props.titleProvider.textColor
+      }}>bar</p>
+    </div>);
+  }
+
+}

--- a/src/domain/block/Block.ts
+++ b/src/domain/block/Block.ts
@@ -2,4 +2,4 @@ import {ReactNode} from 'react';
 
 export default interface Block {
     draw(): ReactNode;
-}
+};

--- a/src/domain/block/BlockFactory.ts
+++ b/src/domain/block/BlockFactory.ts
@@ -4,7 +4,7 @@ import DynamicClass from '../util/DynamicClass';
 
 export default class BlockFactory {
 
-  public static of(blockOption: GetBlockResponse): Block{
+  public static of (blockOption: GetBlockResponse): Block{
     return new DynamicClass(blockOption.blockType, blockOption) as Block;
   }
 

--- a/src/domain/block/CenterBlock.tsx
+++ b/src/domain/block/CenterBlock.tsx
@@ -2,6 +2,7 @@ import {BlockData, GetBlockResponse} from '@domain/block/GetBlockResponse';
 import Block from '@domain/block/Block';
 import React, {ReactNode} from 'react';
 import CompositeBlockComponent from '@components/block/compositeBlock/CompositeBlock';
+import CompositeBlockInteraction from '@domain/plugin/CompositeBlockInteraction';
 
 interface CenterBlockData extends BlockData{
     title: string;
@@ -12,20 +13,22 @@ export default class CenterBlock implements Block {
     //private readonly title: BlockTitle;
     private readonly blockData: CenterBlockData
 
-    public constructor(blockOption: GetBlockResponse){
+    public constructor (blockOption: GetBlockResponse){
       this.blockData = blockOption.blockData as CenterBlockData;
     }
-    public onLeftClick(): void {
+    public onLeftClick (): void {
     }
 
-    public onRightClick(): void {
+    public onRightClick (): void {
     }
 
-    public toString(): string {
+    public toString (): string {
       return this.blockData.title;
     }
 
-    public draw(): ReactNode {
-      return (<CompositeBlockComponent></CompositeBlockComponent>);
+    public draw (): ReactNode {
+      return (<CompositeBlockComponent
+        interaction={new CompositeBlockInteraction()}
+      />);
     }
 }

--- a/src/domain/block/CompositeBlock.tsx
+++ b/src/domain/block/CompositeBlock.tsx
@@ -2,6 +2,8 @@ import {BlockData, GetBlockResponse} from '@domain/block/GetBlockResponse';
 import Block from '@domain/block/Block';
 import React, {ReactNode} from 'react';
 import CompositeBlockComponent from '../../components/block/compositeBlock/CompositeBlock';
+import CompositeBlockOption from '@domain/types/CompositeBlockOption';
+import CompositeBlockInteraction from '@domain/plugin/CompositeBlockInteraction';
 
 interface CompositeBlockData extends BlockData{
     title: string;
@@ -9,17 +11,23 @@ interface CompositeBlockData extends BlockData{
 
 export default class CompositeBlock implements Block {
 
-    private readonly blockData: CompositeBlockData
+    private readonly blockData: CompositeBlockData;
+    private readonly compositeBlockOption: CompositeBlockOption;
+    private interaction: CompositeBlockInteraction;
 
-    public constructor(blockOption: GetBlockResponse){
+    public constructor (blockOption: GetBlockResponse){
       this.blockData = blockOption.blockData as CompositeBlockData;
+      this.compositeBlockOption = blockOption.blockOption as CompositeBlockOption;
+      this.interaction = new CompositeBlockInteraction(this.compositeBlockOption);
     }
 
-    public toString(): string {
+    public toString (): string {
       return this.blockData.title;
     }
 
-    public draw(): ReactNode {
-      return (<CompositeBlockComponent></CompositeBlockComponent>);
+    public draw (): ReactNode {
+      return (<CompositeBlockComponent
+        interaction={this.interaction}
+      />);
     }
 }

--- a/src/domain/block/GetBlockResponse.ts
+++ b/src/domain/block/GetBlockResponse.ts
@@ -1,8 +1,10 @@
 import {BlockTypes} from '@domain/block/BlockTypes';
+import BlockOption from '@domain/types/BlockOption';
 
 export interface GetBlockResponse {
     blockType: BlockTypes;
     blockData: BlockData;
+    blockOption?: BlockOption;
 }
 
 export interface BlockData {

--- a/src/domain/block/LeafBlock.tsx
+++ b/src/domain/block/LeafBlock.tsx
@@ -11,15 +11,15 @@ export default class LeafBlock implements Block{
 
     private readonly blockData: LeafBlockData
 
-    public constructor(blockOption: GetBlockResponse){
+    public constructor (blockOption: GetBlockResponse){
       this.blockData = blockOption.blockData as LeafBlockData;
     }
 
-    public toString(): string {
+    public toString (): string {
       return this.blockData.title;
     }
 
-    public draw(): ReactNode {
+    public draw (): ReactNode {
       return (<LeafBlockComponent></LeafBlockComponent>);
     }
 }

--- a/src/domain/plugin/AbstractBlockActionGroup.ts
+++ b/src/domain/plugin/AbstractBlockActionGroup.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default abstract class AbstractBlockActionGroup {
+
+  onHover (event: React.MouseEvent<HTMLElement>): void {
+    console.log('default hovering'+event.clientX);
+  }
+
+  onLeftClick (): void {
+    //TODO 복합액션 제어
+  }
+
+  onCtrlClick (): void {
+
+  }
+}

--- a/src/domain/plugin/AbstractBlockInteraction.ts
+++ b/src/domain/plugin/AbstractBlockInteraction.ts
@@ -1,0 +1,15 @@
+export default abstract class AbstractBlockInteraction {
+
+    abstract init(): void;
+
+    leftClickHandler () {
+
+    }
+    hoverHandler () {
+
+    }
+    dragHandler () {
+
+    }
+
+}

--- a/src/domain/plugin/CompositeBlockActionGroup.ts
+++ b/src/domain/plugin/CompositeBlockActionGroup.ts
@@ -1,0 +1,20 @@
+import CompositeBlockContentProviderGroup from '@domain/plugin/CompositeBlockContentProviderGroup';
+import AbstractBlockActionGroup from '@domain/plugin/AbstractBlockActionGroup';
+import React from 'react';
+
+export default class CompositeBlockActionGroup extends AbstractBlockActionGroup{
+
+  private contentProviderGroup: CompositeBlockContentProviderGroup;
+
+  constructor ();
+  constructor (contentProviderGroup: CompositeBlockContentProviderGroup);
+  constructor (contentProviderGroup?: any) {
+    super();
+    this.contentProviderGroup = contentProviderGroup;
+  }
+
+  public onHover (event: React.MouseEvent<HTMLElement>): void {
+    console.log('overriden hover '+event.clientX);
+  }
+
+}

--- a/src/domain/plugin/CompositeBlockContentProviderGroup.tsx
+++ b/src/domain/plugin/CompositeBlockContentProviderGroup.tsx
@@ -1,0 +1,31 @@
+import DefaultTitleProvider from '@components/contentProvider/DefaultTitleProvider';
+import TitleProvider from '@components/block/TitleProvider';
+import React from 'react';
+import TitleProviderOption from '@domain/types/TitleProviderOption';
+
+export  default class CompositeBlockContentProviderGroup {
+
+  private readonly defaultTitleProviderOption: TitleProviderOption = {
+    textColor: '#aaa'
+  };
+
+  constructor () {
+
+  }
+
+  getTitleProviderComponent (titleProviderOption?: TitleProviderOption):
+      React.ReactElement<TitleProvider<TitleProviderOption>> {
+
+    if(titleProviderOption){
+      return <DefaultTitleProvider
+        titleProvider={titleProviderOption}
+      />;
+    }else{
+      return <DefaultTitleProvider
+        titleProvider={this.defaultTitleProviderOption}
+      />;
+    }
+
+  }
+
+}

--- a/src/domain/plugin/CompositeBlockInteraction.ts
+++ b/src/domain/plugin/CompositeBlockInteraction.ts
@@ -1,0 +1,44 @@
+import CompositeBlockActionGroup from '@domain/plugin/CompositeBlockActionGroup';
+import CompositeBlockContentProviderGroup from '@domain/plugin/CompositeBlockContentProviderGroup';
+import React from 'react';
+import TitleProvider, {TitleProviderProps} from '@components/block/TitleProvider';
+import CompositeBlockOption from '@domain/types/CompositeBlockOption';
+import TitleProviderOption from '@domain/types/TitleProviderOption';
+
+export default class CompositeBlockInteraction {
+
+    private readonly defaultTitleProviderOption: TitleProviderOption = {
+      textColor: '#aaa'
+    };
+
+    private readonly  option?: CompositeBlockOption;
+    // Make Caller of this class passes props, but not raw props
+    // The props which has partial props to prevent attack
+    private contentProviderGroup: CompositeBlockContentProviderGroup;
+    private actionGroup: CompositeBlockActionGroup;
+
+    public titleProvider: React.ReactElement<TitleProvider<TitleProviderProps>>;
+
+    constructor (options?: CompositeBlockOption) {
+      this.contentProviderGroup = new CompositeBlockContentProviderGroup();
+      this.actionGroup = new CompositeBlockActionGroup(this.contentProviderGroup);
+
+      if(!options){
+        this.titleProvider = this.contentProviderGroup.getTitleProviderComponent();
+        return;
+      }
+      this.titleProvider = this.contentProviderGroup.getTitleProviderComponent(options.titleProviderOption);
+    }
+
+    leftClickHandler () {
+    }
+
+    dragHandler () {
+
+    }
+
+    hoverHandler (event: React.MouseEvent<HTMLElement>): any {
+      return this.actionGroup.onHover(event);
+    }
+
+}

--- a/src/domain/plugin/CompositeBlockPlugin.ts
+++ b/src/domain/plugin/CompositeBlockPlugin.ts
@@ -1,0 +1,10 @@
+import CompositeBlockActionGroup from '@domain/plugin/CompositeBlockActionGroup';
+
+export default abstract class CompositeBlockPlugin {
+
+  private actionGroup: CompositeBlockActionGroup = new CompositeBlockActionGroup();
+
+  showToolTip (){
+
+  }
+}

--- a/src/domain/types/BlockOption.ts
+++ b/src/domain/types/BlockOption.ts
@@ -1,0 +1,2 @@
+export default interface BlockOption {
+};

--- a/src/domain/types/CompositeBlockOption.ts
+++ b/src/domain/types/CompositeBlockOption.ts
@@ -1,0 +1,6 @@
+import BlockOption from '@domain/types/BlockOption';
+import TitleProviderOption from '@domain/types/TitleProviderOption';
+
+export default interface CompositeBlockOption extends BlockOption {
+  titleProviderOption: TitleProviderOption;
+};

--- a/src/domain/types/TitleProviderOption.ts
+++ b/src/domain/types/TitleProviderOption.ts
@@ -1,0 +1,4 @@
+export default interface TitleProviderOption {
+  //TODO plugin interface type
+  textColor: string;
+};

--- a/src/domain/util/DynamicClass.ts
+++ b/src/domain/util/DynamicClass.ts
@@ -1,7 +1,7 @@
 import {Store} from '../block/BlockTypeStore';
 
 export default class DynamicClass {
-  public constructor(className: string, opts?: any) {
+  public constructor (className: string, opts?: any) {
     if (Store[className] === undefined || Store[className] === null) {
       throw new Error(`Class type of \'${className}\' is not in the store`);
     }

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -5,7 +5,7 @@ import {Main} from 'pages';
 import Board from '../../src/pages/board/index';
 
 export default class Layout extends React.Component {
-  render(): ReactNode {
+  render (): ReactNode {
     return (
       <div>
         <div>

--- a/src/pages/Another.tsx
+++ b/src/pages/Another.tsx
@@ -2,7 +2,7 @@ import React, {ReactNode} from 'react';
 import TestComponentTwo from 'components/TestComponentTwo';
 
 export default class Another extends React.Component {
-  render(): ReactNode {
+  render (): ReactNode {
     return (
       <div>
         <h1>another page</h1>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -5,7 +5,7 @@ import TestComponentOne from 'components/TestComponentOne';
 import './style/Main.scss';
 
 export default class Main extends React.Component {
-  render(): ReactNode {
+  render (): ReactNode {
     return (
       <div className={'page-wrapper'}>
         <h1 className={'page-title'}>main page</h1>

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -7,10 +7,15 @@ import BlockFactory from '@domain/block/BlockFactory';
 
 import './styles.scss';
 
-const mockCompositeBlock: GetBlockResponse = {
-  blockType: BlockTypes.COMPOSITE,
-  blockData: {
-    title: 'hello world!'
+const mockCompositeBlock: any = {
+  'blockType': BlockTypes.COMPOSITE,
+  'blockData': {
+    'title': 'hello world!'
+  },
+  'blockOption': {
+    'titleProviderOption': {
+      'textColor': '#ffc125'
+    }
   }
 };
 
@@ -43,7 +48,7 @@ export const mockResponse: GetBoardResponse = {
 
 export default class Board extends React.Component {
 
-  private drawBoard(): ReactNode[]{
+  private drawBoard (): ReactNode[]{
     const blockResponses: GetBlockResponse[] = mockResponse.blocks;
     const blocks: ReactNode[] = [];
     for(let i=0; i < blockResponses.length; i++){
@@ -54,7 +59,7 @@ export default class Board extends React.Component {
     return blocks;
   }
 
-  public render(): ReactNode {
+  public render (): ReactNode {
     return (
       <div>
         <div className={'board'}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/lodash@^4.14.144":
+  version "4.14.144"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
+  integrity sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==
+
 "@types/node@^12.7.5":
   version "12.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
@@ -6091,6 +6096,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash-webpack-plugin@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz#c4bd064b4f561c3f823fa5982bdeb12c475390b9"
+  integrity sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==
+  dependencies:
+    lodash "^4.17.4"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6131,7 +6143,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
저번 커밋 소스가 플러그인 넣는데 extensibility 가 좋지 않은 것 같아서 draft 로 설계해봤습니다
일단은, 

```
const mockCompositeBlock: any = {

  'blockType': BlockTypes.COMPOSITE,
  'blockData': {
    'title': 'hello world!'
  },
  'blockOption': {
    'titleProviderOption': {
      'textColor': '#ffc125'
    }
  }
};
```
와 같이 response 를 가정해보았습니다. 지금 커밋올린 버전으로는 서버에서 가지고 있는 플러그인 정보로
색깔을 바꿀 수 있습니다.
위에서 blockOption 에 titleProviderOption 을 plugin 같은 key 아래로 넣어지던가 
gradle 처럼 url 기반으로 레포지터리에서 받는 방향도 괜찮을 것 같은데.. 아직 잘 모르겠네요
엄밀히는 플러그인이라고 말하기는 어렵고, Plugin을 구현한다면 적용할 수 있는 상태로만 있고 
색깔 바꾸는 것은 Plugin을 destructuring 했다고 가정하고 해봤습니다.

Interaction :  actionGroup 과 contentProviderGroup(title,content)
으로 나누었습니다. actionGroup 은 onHover, onClick 과 같은 이벤트핸들러를 기본으로 가지고 있고
override 해서 플러그인으로 넣을 수 있게하려고 합니다
contentProviderGroup, 제목, 내용(그냥 텍스트 메모부터, Assigning, sns 연동,github, travisCI 같은 서비스)

AbstractBlockInteraction -> CompositeBlockInteraction 
BlockComponent (view 가 아닌 domain class)
---  Interaction 생성 ---> CompositeBlockComponent의 props 의 property로 주입


![Screenshot from 2019-10-14 02-03-46](https://user-images.githubusercontent.com/34095479/66719275-ae301500-ee28-11e9-83b2-fe65bfe762e9.png)
